### PR TITLE
fix-bürgermeister-weitergeben-bug

### DIFF
--- a/Werwolf.php
+++ b/Werwolf.php
@@ -215,7 +215,7 @@ p#liste {
                   //Weiters schauen wir noch, ob der Bürgermeister sein Amt weitergeben muss...
                   $buergermeisterRes = $mysqli->Query("SELECT * FROM $spielID"."_spieler WHERE buergermeisterDarfWeitergeben = 1");
                   $gameAssoc = gameAssoc($mysqli); //Nur Bürgermeister weitergeben, wenn das Spiel noch nicht aus ist
-                  if ($buergermeisterRes->num_rows > 0 && $gameAssoc['spielphase'] != PHASESIEGEREHRUNG)
+                  if ($buergermeisterRes->num_rows > 0 && $gameAssoc['spielphase'] != PHASESIEGEREHRUNG && $gameAssoc['spielphase'] != PHASESPIELSETUP && $gameAssoc['spielphase'] != PHASESETUP)
                   {
                     //Der Bürgermeister wurde getötet und darf sein Amt weitergeben ...
                     $buergermA = $buergermeisterRes->fetch_assoc();

--- a/constants.php
+++ b/constants.php
@@ -1,6 +1,6 @@
 <?php
 //Constants
-define("_VERSION","v1.2.2");
+define("_VERSION","v1.2.3");
 define("_LISTMAXRELOADTIME",3000);
 
 //Phasen 


### PR DESCRIPTION
Fix: If "Bürgermeister" is killed last and he has to choose a new one and if a new game is started, he has to choose a new one before the new game can be started.
Also changed version